### PR TITLE
Fix Travis configuration for Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 install: true
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 script:
   - mvn verify -B -e -V


### PR DESCRIPTION
Fix Travis configuration for Java 8

Java 8 is required for upgrading to API 5.6.